### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         "illuminate/encryption": "^5.0",
         "illuminate/container": "^5.0",
         "illuminate/config": "^5.0",
-        "illuminate/console": "^5.0",
-        "paragonie/random_compat": "^1.1|^2.0"
+        "illuminate/console": "^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",


### PR DESCRIPTION
This package depends on `paragonie/random_compat: ^1.1|^2.0`, but also `php: >=7.0`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?